### PR TITLE
Publish composer package on tag and branch push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,11 @@ matrix:
   include:
     - PHP_VERSION: 7.3.3
 
+clone:
+  git:
+    image: plugins/git
+    tags: true
+
 pipeline:
   chown: # we need to do this since our test container runs with www-data and drone clones with root
     image: debian:stretch-slim
@@ -65,6 +70,34 @@ pipeline:
       event: push
       branch:
         include: ['*-branch']
+
+  publish-composer-package-branch:
+    image: quay.io/presslabs/bfc
+    environment:
+      - GIT_USER=presslabs-bot
+      - GIT_EMAIL=bot@presslabs.com
+      - RELEASE_UPSTREAM=https://github.com/presslabs/stack-wordpress-release
+    secrets: [GIT_PASSWORD]
+    commands:
+      - setup-credentials-helper.sh
+      - ./hack/publish branch ${DRONE_BRANCH}
+    when:
+      event: push
+      branch:
+        include: ['*-branch']
+
+  publish-composer-package-tag:
+    image: quay.io/presslabs/bfc
+    environment:
+      - GIT_USER=presslabs-bot
+      - GIT_EMAIL=bot@presslabs.com
+      - RELEASE_UPSTREAM=https://github.com/presslabs/stack-wordpress-release
+    secrets: [GIT_PASSWORD]
+    commands:
+      - setup-credentials-helper.sh
+      - ./hack/publish tag ${DRONE_TAG}
+    when:
+      event: tag
 
 services:
   database:

--- a/.drone.yml
+++ b/.drone.yml
@@ -71,7 +71,7 @@ pipeline:
       branch:
         include: ['*-branch']
 
-  publish-composer-package-branch:
+  publish-composer-package:
     image: quay.io/presslabs/bfc
     environment:
       - GIT_USER=presslabs-bot
@@ -80,13 +80,13 @@ pipeline:
     secrets: [GIT_PASSWORD]
     commands:
       - setup-credentials-helper.sh
-      - ./hack/publish branch ${DRONE_BRANCH}
+      - ./hack/publish branch ${DRONE_BRANCH%%-branch}
     when:
       event: push
       branch:
         include: ['*-branch']
 
-  publish-composer-package-tag:
+  publish-composer-package:
     image: quay.io/presslabs/bfc
     environment:
       - GIT_USER=presslabs-bot

--- a/hack/publish
+++ b/hack/publish
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eo pipefail
+
+DEFAULT_BRANCH="5.1-branch"
+UPSTREAM=${RELEASE_UPSTREAM:-https://github.com/presslabs/stack-wordpress-release}
+WORDPRESS_PREFIX=${WORDPRESS_PREFIX:-wordpress}
+
+print_usage() {
+    echo "publish branch|tag version" >&2
+}
+
+if [[ -z "$1" || "$1" == "-h" || -z "$2" ]] ; then
+    print_usage
+    exit 1
+fi
+
+publish_branch() {
+    branch=${1:-$DEFAULT_BRANCH}
+    remote_branch=${branch%"-branch"}
+
+    has_remote=$(git ls-remote --heads "${UPSTREAM}" "${remote_branch}")
+    if [[ -z $has_remote ]] ; then
+        git subtree push --prefix="${WORDPRESS_PREFIX}" "${UPSTREAM}" "${remote_branch}"
+    else
+        subtree=$(git subtree split --prefix="${WORDPRESS_PREFIX}" "${branch}")
+        git push "${UPSTREAM}" --force "${subtree}":"${remote_branch}"
+    fi
+}
+
+publish_tag() {
+    tag="$1"
+
+    git subtree split --prefix="${WORDPRESS_PREFIX}" -b "branch_${tag}"
+
+    git checkout "branch_${tag}"
+
+    commit=$(git show -s HEAD --pretty="format:%h")
+    message=$(git for-each-ref refs/tags/"$tag" --format='%(contents)')
+    meta="git-tag-source: $UPSTREAM@$commit"
+
+    if [[ -z "$message" ]] ; then
+        message="$meta"
+    else
+        message="$(echo -e "$message\\n\\n$meta")"
+    fi
+
+    git tag -a "tag_$tag" -m "$message"
+    git push "${UPSTREAM}" --force "tag_$tag":"${tag}"
+}
+
+case $1 in
+    branch)
+      publish_branch $2
+      ;;
+
+    tag)
+      publish_tag $2
+      ;;
+
+    *)
+      print_usage
+      exit
+esac

--- a/hack/publish
+++ b/hack/publish
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-DEFAULT_BRANCH="5.1-branch"
 UPSTREAM=${RELEASE_UPSTREAM:-https://github.com/presslabs/stack-wordpress-release}
 WORDPRESS_PREFIX=${WORDPRESS_PREFIX:-wordpress}
 
@@ -15,16 +14,15 @@ if [[ -z "$1" || "$1" == "-h" || -z "$2" ]] ; then
 fi
 
 publish_branch() {
-    branch=${1:-$DEFAULT_BRANCH}
-    remote_branch=${branch%"-branch"}
+    remote_branch="refs/heads/$1"
+    subtree=$(git subtree split --prefix="${WORDPRESS_PREFIX}" HEAD)
 
     has_remote=$(git ls-remote --heads "${UPSTREAM}" "${remote_branch}")
-    if [[ -z $has_remote ]] ; then
-        git subtree push --prefix="${WORDPRESS_PREFIX}" "${UPSTREAM}" "${remote_branch}"
-    else
-        subtree=$(git subtree split --prefix="${WORDPRESS_PREFIX}" "${branch}")
-        git push "${UPSTREAM}" --force "${subtree}":"${remote_branch}"
+    git_push="git push"
+    if [[ -n "$has_remote" ]] ; then
+        git_push="git push --force"
     fi
+    $git_push "${UPSTREAM}" "${subtree}":"${remote_branch}"
 }
 
 publish_tag() {
@@ -45,16 +43,17 @@ publish_tag() {
     fi
 
     git tag -a "tag_$tag" -m "$message"
-    git push "${UPSTREAM}" --force "tag_$tag":"${tag}"
+    git push "${UPSTREAM}" --force "tag_${tag}:${tag}"
 }
 
+set -x
 case $1 in
     branch)
-      publish_branch $2
+      publish_branch "$2"
       ;;
 
     tag)
-      publish_tag $2
+      publish_tag "$2"
       ;;
 
     *)


### PR DESCRIPTION
Setup a publishing pipeline on `drone`. We use the `git subtree` utility that commits the `wordpress` directory on https://github.com/presslabs/stack-wordpress-release.

#### Tests
* `git checkout setup-release`


##### Branches
* `./hack/publish branch 5.1-branch`
* it **should** push the `wordpress` directory as the root directory of https://github.com/presslabs/stack-wordpress-release/tree/5.1

* `git checkout -b 5.1.1-branch`
* `./hack/publish branch 5.1.1-branch`
* it **should** push the `wordpress` directory as the root directory of https://github.com/presslabs/stack-wordpress-release/tree/5.1.1

##### Tags
* create a new tag
* `./hack/publish branch 5.1-branch`
* it **should** push the `wordpress` directory as the root directory of `https://github.com/presslabs/stack-wordpress-release/tree/<tag>`