### PR TITLE
Cache directly built keys [ch64]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ DB_PASSWORD=database_password
 # DB_HOST=localhost
 # DB_PREFIX=wp_
 
+# DB_TEST_USER=wordpress
+# DB_TEST_PASSWORD=wordpress
+# DB_TEST_HOST=127.0.0.1:3306
+
 # UPLOADS_HTTP_PROXY=<host>:<port>
 
 # UPLOADS_FTP_HOST=<host>:<port>

--- a/wordpress/wp-oem/Presslabs/Config.php
+++ b/wordpress/wp-oem/Presslabs/Config.php
@@ -10,6 +10,7 @@ class Config
         if ($runCount > 0) {
             return;
         }
+        self::defineFromEnv("DOBJECT_CACHE_PRELOAD", false);
 
         self::defineFromEnv("MEMCACHED_HOST", "");
         self::defineFromEnv("MEMCACHED_DISCOVERY_HOST", "");

--- a/wordpress/wp-oem/Presslabs/ObjectCache/Memcached.php
+++ b/wordpress/wp-oem/Presslabs/ObjectCache/Memcached.php
@@ -196,7 +196,7 @@ class Memcached implements \Presslabs\ObjectCache
             $this->preload = array();
         }
 
-        $this->getMulti($this->preload, array());
+        $this->getMulti(array_keys($this->preload), array());
     }
 
     public function updatePreloadKeys()
@@ -676,11 +676,7 @@ class Memcached implements \Presslabs\ObjectCache
 
         // Assume object is not found
         $found = false;
-
         ++$this->stats['get'];
-        if ($group != 'object-cache-preload' && !in_array($group, $this->no_mc_groups)) {
-            $this->preload[$derived_key] = true;
-        }
 
         // If either $cache_db, or $cas_token is set, must hit Memcached and bypass runtime cache
         if (func_num_args() > 6 && ! in_array($group, $this->no_mc_groups)) {
@@ -725,7 +721,11 @@ class Memcached implements \Presslabs\ObjectCache
         }
 
         if (\Memcached::RES_SUCCESS === $this->getResultCode()) {
-            $this->add_to_internal_cache($derived_key, $value);
+            if ($group != 'object-cache-preload' && isset($value) && !in_array($group, $this->no_mc_groups) ) {
+                    $this->add_to_internal_cache($derived_key, $value);
+                    $this->preload[$derived_key] = true;
+            }
+
             $found = true;
         }
 


### PR DESCRIPTION
Improve the overall performance of the object cache by:
   * cache build keys directly
   * cache only not null values
   * allow preload mechanism to be turned on from env

```
+------------+-------+-------------+---------+--------+---------+---------+---------+
|            |   Req |    Homepage |         |  Post  |         | Listing |         |
+------------+-------+-------------+---------+--------+---------+---------+---------+
|            |       | Media       | Average | Media  | Average | Media   | Average |
+------------+-------+-------------+---------+--------+---------+---------+---------+
| Base       |       | 370         | 399     | 600    | 636     | 930     | 977     |
+------------+-------+-------------+---------+--------+---------+---------+---------+
| no preload |  1200 | 430         | 440     | 720    | 732     | 1100    | 1164    |
|            |       | 16.22%      | 10.28%  | 20.00% | 15.09%  | 18.28%  | 19.14%  |
+------------+-------+-------------+---------+--------+---------+---------+---------+
| preload    |  1200 | 460         | 473     | 760    | 786     | 1200    | 1260    |
|            |       | 19.57%      | 15.64%  | 21.05% | 19.08%  | 22.50%  | 22.46%  |
+------------+-------+-------------+---------+--------+---------+---------+---------+
| preload    |       |             |         |        |         |         |         |
| optimized  |  1500 | 420         | 426     | 690    | 700     | 1000    | 1042    |
|            |       | 11.90%      | 6.34%   | 13.04% | 9.14%   | 7.00%   | 6.24%   |
+------------+-------+-------------+---------+--------+---------+---------+---------+
|            |       | 4.31%       | 3.94%   | 6.96%  | 5.95%   | 11.28%  | 12.90%  |
+------------+-------+-------------+---------+--------+---------+---------+---------+
```